### PR TITLE
Change Styling for `responseProperties`

### DIFF
--- a/resources/views/responseProperties.blade.php
+++ b/resources/views/responseProperties.blade.php
@@ -1,24 +1,20 @@
-<div class="mx-4 my-1 ">
-    <div class="m-1 w-full max-w-80 {{ $bgColor }}">
-        <div class="w-full text-white text-center"></div>
-        <div class="w-full text-white">
-        <span class="px-2 text-left w-1/2">
-            <span class="uppercase mr-1">{{ $method }}</span>
+<div class="ml-2 my-1">
+    <div class="w-full {{ $headerStyle }} py-1 px-2 max-w-100">
+        <span class="text-left w-1/2">
+            <span class="uppercase font-bold mr-1">{{ $method }}</span>
             <span>{{ $url }}</span>
         </span>
-            <span class="px-2 text-right w-1/2">
+        <span class="text-right w-1/2">
             {{ $statusCode }}
         </span>
-        </div>
-        <div class="w-full text-white text-center"></div>
     </div>
 
     @if($showHeaders)
-        <div class="underline mb-1">Headers</div>
-
-
-            @foreach($headers as $name => $value)
-                <div><span class="text-white">{{ $name }}</span>: {{ $value[0] }}</div>
-            @endforeach
+        <div class="underline mt-1">Headers:</div>
+        @foreach ($headers as $name => $value)
+            <div>
+                <span class="font-bold text-gray capitalize">{{ $name }}:</span> {{ $value[0] }}
+            </div>
+        @endforeach
     @endif
 </div>

--- a/src/Commands/VisitCommand.php
+++ b/src/Commands/VisitCommand.php
@@ -153,7 +153,7 @@ class VisitCommand extends Command
             'content' => $response->content(),
             'headers' => $response->headers->all(),
             'showHeaders' => $this->option('show-headers'),
-            'bgColor' => $this->getHeaderBackgroundColor($response),
+            'headerStyle' => $this->getHeaderStyle($response),
         ]);
 
         render($requestProperties);
@@ -161,13 +161,13 @@ class VisitCommand extends Command
         return $this;
     }
 
-    protected function getHeaderBackgroundColor(TestResponse $response): string
+    protected function getHeaderStyle(TestResponse $response): string
     {
         if ($response->isSuccessful() || $response->isRedirect()) {
-            return 'bg-green-800';
+            return 'bg-green text-black';
         }
 
-        return 'bg-red-800';
+        return 'bg-red text-white';
     }
 
     protected function getColorizer(TestResponse $response): Colorizer


### PR DESCRIPTION
This PR adds some style tweaks for the CLI Output.

## New look:

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/823088/154949866-463ce440-6454-40d7-8d4c-49deb9e2d9c7.png">