### PR TITLE
Use `justify-between` instead of `w-1/2`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^9.0",
-        "nunomaduro/termwind": "^1.5",
+        "nunomaduro/termwind": "^1.7",
         "soundasleep/html2text": "^2.0",
         "spatie/laravel-package-tools": "^1.11.1",
         "symfony/css-selector": "^6.0",

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -1,11 +1,11 @@
 <div class="ml-2 my-1">
     <div class="w-full {{ $headerStyle }} max-w-100"></div>
-    <div class="w-full {{ $headerStyle }} px-2 max-w-100">
-        <span class="text-left w-1/2">
+    <div class="w-full {{ $headerStyle }} px-2 max-w-100 justify-between">
+        <span>
             <span class="uppercase font-bold mr-1">{{ $method }}</span>
             <span>{{ $url }}</span>
         </span>
-        <span class="text-right w-1/2">
+        <span>
             {{ $statusCode }}
         </span>
     </div>


### PR DESCRIPTION
With **Termwind** v1.7, instead of using `w-1/2` and text alignment we can take advantage of the `justify-between` helper.

💪